### PR TITLE
Updating distributor_type to distributor_type_id based on

### DIFF
--- a/tests/test_2_repo_cud.py
+++ b/tests/test_2_repo_cud.py
@@ -20,7 +20,7 @@ class RepoCudTest(pulp_test.PulpTest):
                                             {
                                              "distributor_id": "yum_distributor",
                                              "auto_publish": False,
-                                             "distributor_type": "yum_distributor",
+                                             "distributor_type_id": "yum_distributor",
                                              "distributor_config": {"http": False, "relative_url": cls.__name__ + "_repo", "https": True}
                                             }
                                         ],
@@ -36,7 +36,7 @@ class RepoCudTest(pulp_test.PulpTest):
                                                  {
                                                   "distributor_id": "yum_distributor",
                                                   "auto_publish": False,
-                                                  "distributor_type": "yum_distributor",
+                                                  "distributor_type_id": "yum_distributor",
                                                   "distributor_config": {"http": False, "relative_url": cls.__name__ + "_repo1", "https": True}
                                                  }
                                              ],
@@ -53,7 +53,7 @@ class RepoCudTest(pulp_test.PulpTest):
                                                  {
                                                   "distributor_id": "yum_distributor",
                                                   "auto_publish": False,
-                                                  "distributor_type": "yum_distributor",
+                                                  "distributor_type_id": "yum_distributor",
                                                   "distributor_config": {"http": False, "https": True}
                                                  }
                                              ],


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1093429
based on the bug above distributor_type has been updated to distributor_type_id to match the doc
http://pulp-dev-guide.readthedocs.org/en/latest/integration/rest-api/repo/cud.html
