### PR TITLE
unpin qpid-python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='pulp_auto',
       author_email='vetrisko@gmail.com',
       url='https://github.com/RedHatQE/pulp-automation',
       license='GPLv3+',
-      install_requires=['nose>=1.3.0', 'requests>=1.2.3', 'PyYAML', 'qpid-python==0.26',
+      install_requires=['nose>=1.3.0', 'requests>=1.2.3', 'PyYAML', 'qpid-python>=0.27',
             'gevent>=1.0.1', 'stitches', 'M2Crypto', 'requestbin>0.1'],
       classifiers=[
           'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',


### PR DESCRIPTION
The bug that forced the pin to 0.26 has been fixed. https://pulp.plan.io/issues/1081#note-2
